### PR TITLE
docs: use a human-readable README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Demo](demo.gif) [![Backend Tests Status](https://github.com/ether/ep_button_link/actions/workflows/test-and-release.yml/badge.svg)](https://github.com/ether/ep_button_link/actions/workflows/test-and-release.yml)
 
-# ep_button_link
+# Toolbar Button Links for Etherpad
 
 [Etherpad](https://etherpad.org) plugin to add custom buttons to the toolbar.
 


### PR DESCRIPTION
Replace the placeholder `ep_button_link` heading in README.md with "Toolbar Button Links for Etherpad" so browsers of the plugin list on GitHub / npm can see what the plugin does at a glance.