### PR TITLE
fix: backward-compat for ESM etherpad

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const log4js = require('ep_etherpad-lite/node_modules/log4js');
+const {createLogger} = require('ep_plugin_helpers/logger');
 
-const logger = log4js.getLogger('ep_button_link');
+const logger = createLogger('ep_button_link');
 let settings = null;
 
 exports.clientVars = async (hookName, context) => ({ep_button_link: settings});

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ep_button_link",
   "description": "Adds a button to the toolbar that links out to a new window",
-  "version": "1.0.49",
+  "version": "1.0.50",
   "author": "johnyma22 (John McLear) <john@mclear.co.uk>",
   "engines": {
     "node": ">=18.0.0"
@@ -22,5 +22,8 @@
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint --fix ."
+  },
+  "dependencies": {
+    "ep_plugin_helpers": "^0.6.7"
   }
 }


### PR DESCRIPTION
This PR makes the plugin backward-compatible with the upcoming ESM etherpad branch (ether/etherpad#7605).

**Change:** Migrate log4js from `require("ep_etherpad-lite/node_modules/log4js")` to `ep_plugin_helpers/logger`

This change is **backward-compatible** with the current CJS etherpad release.